### PR TITLE
CTCTRADERS-1455 Add streaming of reference data items

### DIFF
--- a/app/api/models/AdditionalInformation.scala
+++ b/app/api/models/AdditionalInformation.scala
@@ -16,13 +16,15 @@
 
 package api.models
 
-import play.api.libs.json.Format
 import play.api.libs.json.Json
+import play.api.libs.json.OWrites
+import play.api.libs.json.Reads
 
 case class AdditionalInformation(code: String, description: String)
 
 object AdditionalInformation {
 
-  implicit lazy val format: Format[AdditionalInformation] =
-    Json.format[AdditionalInformation]
+  implicit val writes: OWrites[AdditionalInformation] = Json.writes[AdditionalInformation]
+
+  implicit val readFromFile: Reads[AdditionalInformation] = Json.reads[AdditionalInformation]
 }

--- a/app/api/models/CircumstanceIndicator.scala
+++ b/app/api/models/CircumstanceIndicator.scala
@@ -17,10 +17,15 @@
 package api.models
 
 import play.api.libs.json.Json
-import play.api.libs.json.OFormat
+import play.api.libs.json.OWrites
+import play.api.libs.json.Reads
 
 case class CircumstanceIndicator(code: String, description: String)
 
 object CircumstanceIndicator {
-  implicit val format: OFormat[CircumstanceIndicator] = Json.format[CircumstanceIndicator]
+
+  implicit val writes: OWrites[CircumstanceIndicator] = Json.writes[CircumstanceIndicator]
+
+  implicit val readFromFile: Reads[CircumstanceIndicator] = Json.reads[CircumstanceIndicator]
+
 }

--- a/app/api/models/Country.scala
+++ b/app/api/models/Country.scala
@@ -17,11 +17,15 @@
 package api.models
 
 import play.api.libs.json.Json
-import play.api.libs.json.Format
+import play.api.libs.json.OWrites
+import play.api.libs.json.Reads
 
 case class Country(state: String, code: String, description: String)
 
 object Country {
 
-  implicit val format: Format[Country] = Json.format[Country]
+  implicit val writes: OWrites[Country] = Json.writes[Country]
+
+  implicit val readFromFile: Reads[Country] = Json.reads[Country]
+
 }

--- a/app/api/models/CustomsOffice.scala
+++ b/app/api/models/CustomsOffice.scala
@@ -16,9 +16,9 @@
 
 package api.models
 
-import play.api.libs.json._
-import play.api.libs.json.Reads._
 import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads._
+import play.api.libs.json._
 
 case class CustomsOffice(
   id: String,
@@ -30,7 +30,9 @@ case class CustomsOffice(
 
 object CustomsOffice {
 
-  implicit def reads: Reads[CustomsOffice] =
+  implicit val writes: OWrites[CustomsOffice] = Json.writes[CustomsOffice]
+
+  implicit val readFromFile: Reads[CustomsOffice] =
     (
       (__ \ "CUST_OFF_ID").read[String] and
         (__ \ "CUST_OFF_NAM").read[String] and
@@ -39,5 +41,4 @@ object CustomsOffice {
         (__ \ "CUSTOMS_OFFICE_ROLES").read[Seq[String]]
     )(CustomsOffice.apply _)
 
-  implicit def writes: Writes[CustomsOffice] = Json.writes[CustomsOffice]
 }

--- a/app/api/models/DangerousGoodsCode.scala
+++ b/app/api/models/DangerousGoodsCode.scala
@@ -16,19 +16,16 @@
 
 package api.models
 
-import play.api.libs.functional.syntax._
 import play.api.libs.json.Json
+import play.api.libs.json.OWrites
 import play.api.libs.json.Reads
-import play.api.libs.json.Writes
-import play.api.libs.json.__
 
 final case class DangerousGoodsCode(code: String, description: String)
 
 object DangerousGoodsCode {
 
-  implicit def reads: Reads[DangerousGoodsCode] =
-    ((__ \ "code").read[String] and
-      (__ \ "description").read[String])(DangerousGoodsCode.apply _)
+  implicit val writes: OWrites[DangerousGoodsCode] = Json.writes[DangerousGoodsCode]
 
-  implicit def writes: Writes[DangerousGoodsCode] = Json.writes[DangerousGoodsCode]
+  implicit val readFromFile: Reads[DangerousGoodsCode] = Json.reads[DangerousGoodsCode]
+
 }

--- a/app/api/models/DocumentType.scala
+++ b/app/api/models/DocumentType.scala
@@ -16,13 +16,16 @@
 
 package api.models
 
-import play.api.libs.json.Format
 import play.api.libs.json.Json
+import play.api.libs.json.OWrites
+import play.api.libs.json.Reads
 
 final case class DocumentType(code: String, description: String, transportDocument: Boolean)
 
 object DocumentType {
 
-  implicit lazy val format: Format[DocumentType] =
-    Json.format[DocumentType]
+  implicit val writes: OWrites[DocumentType] = Json.writes[DocumentType]
+
+  implicit val readFromFile: Reads[DocumentType] = Json.reads[DocumentType]
+
 }

--- a/app/api/models/KindOfPackage.scala
+++ b/app/api/models/KindOfPackage.scala
@@ -16,13 +16,16 @@
 
 package api.models
 
-import play.api.libs.json.Format
 import play.api.libs.json.Json
+import play.api.libs.json.OWrites
+import play.api.libs.json.Reads
 
 case class KindOfPackage(code: String, description: String)
 
 object KindOfPackage {
 
-  implicit lazy val format: Format[KindOfPackage] =
-    Json.format[KindOfPackage]
+  implicit val writes: OWrites[KindOfPackage] = Json.writes[KindOfPackage]
+
+  implicit val readFromFile: Reads[KindOfPackage] = Json.reads[KindOfPackage]
+
 }

--- a/app/api/models/MethodOfPayment.scala
+++ b/app/api/models/MethodOfPayment.scala
@@ -16,13 +16,16 @@
 
 package api.models
 
-import play.api.libs.json.Format
 import play.api.libs.json.Json
+import play.api.libs.json.OWrites
+import play.api.libs.json.Reads
 
 final case class MethodOfPayment(code: String, description: String)
 
 object MethodOfPayment {
 
-  implicit lazy val format: Format[MethodOfPayment] =
-    Json.format[MethodOfPayment]
+  implicit val writes: OWrites[MethodOfPayment] = Json.writes[MethodOfPayment]
+
+  implicit val readFromFile: Reads[MethodOfPayment] = Json.reads[MethodOfPayment]
+
 }

--- a/app/api/models/OfficeOfTransit.scala
+++ b/app/api/models/OfficeOfTransit.scala
@@ -18,17 +18,18 @@ package api.models
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Json
+import play.api.libs.json.OWrites
 import play.api.libs.json.Reads
-import play.api.libs.json.Writes
 import play.api.libs.json.__
 
 case class OfficeOfTransit(id: String, name: String)
 
 object OfficeOfTransit {
 
-  implicit def reads: Reads[OfficeOfTransit] =
+  implicit val writes: OWrites[OfficeOfTransit] = Json.writes[OfficeOfTransit]
+
+  implicit val readFromFile: Reads[OfficeOfTransit] =
     ((__ \ "ID").read[String] and
       (__ \ "NAME").read[String])(OfficeOfTransit.apply _)
 
-  implicit def writes: Writes[OfficeOfTransit] = Json.writes[OfficeOfTransit]
 }

--- a/app/api/models/PreviousDocumentType.scala
+++ b/app/api/models/PreviousDocumentType.scala
@@ -16,13 +16,16 @@
 
 package api.models
 
-import play.api.libs.json.Format
 import play.api.libs.json.Json
+import play.api.libs.json.OWrites
+import play.api.libs.json.Reads
 
 case class PreviousDocumentType(code: String, description: String)
 
 object PreviousDocumentType {
 
-  implicit lazy val format: Format[PreviousDocumentType] =
-    Json.format[PreviousDocumentType]
+  implicit val writes: OWrites[PreviousDocumentType] = Json.writes[PreviousDocumentType]
+
+  implicit val readFromFile: Reads[PreviousDocumentType] = Json.reads[PreviousDocumentType]
+
 }

--- a/app/api/models/SpecialMention.scala
+++ b/app/api/models/SpecialMention.scala
@@ -16,13 +16,16 @@
 
 package api.models
 
-import play.api.libs.json.Format
 import play.api.libs.json.Json
+import play.api.libs.json.OWrites
+import play.api.libs.json.Reads
 
 final case class SpecialMention(code: String, description: String)
 
 object SpecialMention {
 
-  implicit lazy val format: Format[SpecialMention] =
-    Json.format[SpecialMention]
+  implicit val writes: OWrites[SpecialMention] = Json.writes[SpecialMention]
+
+  implicit val readFromFile: Reads[SpecialMention] = Json.reads[SpecialMention]
+
 }

--- a/app/api/models/State.scala
+++ b/app/api/models/State.scala
@@ -16,11 +16,7 @@
 
 package api.models
 
-import play.api.libs.json.JsError
-import play.api.libs.json.JsString
-import play.api.libs.json.JsSuccess
-import play.api.libs.json.Reads
-import play.api.libs.json.Writes
+import play.api.libs.json._
 
 sealed trait State
 

--- a/app/api/models/TransportMode.scala
+++ b/app/api/models/TransportMode.scala
@@ -17,10 +17,15 @@
 package api.models
 
 import play.api.libs.json.Json
-import play.api.libs.json.OFormat
+import play.api.libs.json.OWrites
+import play.api.libs.json.Reads
 
 case class TransportMode(state: State, activeFrom: String, code: String, description: String)
 
 object TransportMode {
-  implicit val format: OFormat[TransportMode] = Json.format[TransportMode]
+
+  implicit val writes: OWrites[TransportMode] = Json.writes[TransportMode]
+
+  implicit val readFromFile: Reads[TransportMode] = Json.reads[TransportMode]
+
 }

--- a/app/data/DataRetrieval.scala
+++ b/app/data/DataRetrieval.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data
+
+import models.ListName
+import play.api.libs.json.Reads
+
+import scala.concurrent.Future
+
+trait DataRetrieval {
+
+  def getList[A: Reads](list: ListName): Future[Seq[A]]
+
+}

--- a/app/data/RefDataSource.scala
+++ b/app/data/RefDataSource.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data
+
+import akka.NotUsed
+import akka.stream.scaladsl.Source
+import data.connector.RefDataConnector
+import javax.inject.Inject
+import models.ListName
+import play.api.libs.json.JsObject
+
+private[data] class RefDataSource @Inject() (refDataConnector: RefDataConnector, referenceDataJsonProjection: ReferenceDataJsonProjection)
+    extends (ListName => Source[JsObject, NotUsed]) {
+
+  def apply(listName: ListName): Source[JsObject, NotUsed] =
+    Source
+      .future(refDataConnector.get(listName))
+      .via(referenceDataJsonProjection.dataElements)
+
+}

--- a/app/data/ReferenceDataJsonProjection.scala
+++ b/app/data/ReferenceDataJsonProjection.scala
@@ -27,7 +27,7 @@ import logging.StreamLoggerAdapter
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
 
-private[data] class ReferenceDataJsonProjection @Inject()(streamLoggingConfig: StreamLoggingConfig) extends StreamLoggerAdapter {
+private[data] class ReferenceDataJsonProjection @Inject() (streamLoggingConfig: StreamLoggingConfig) extends StreamLoggerAdapter {
 
   val (onElement, onFinish, onFailure) = streamLoggingConfig.loggingConfig(None)
 

--- a/app/data/ReferenceDataJsonProjection.scala
+++ b/app/data/ReferenceDataJsonProjection.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data
+
+import akka.NotUsed
+import akka.stream.Attributes
+import akka.stream.alpakka.json.scaladsl.JsonReader
+import akka.stream.scaladsl.Flow
+import akka.util.ByteString
+import data.config.StreamLoggingConfig
+import javax.inject.Inject
+import logging.StreamLoggerAdapter
+import play.api.libs.json.JsObject
+import play.api.libs.json.Json
+
+private[data] class ReferenceDataJsonProjection @Inject()(streamLoggingConfig: StreamLoggingConfig) extends StreamLoggerAdapter {
+
+  val (onElement, onFinish, onFailure) = streamLoggingConfig.loggingConfig(None)
+
+  private val pathToNestedData = "$.data[*]"
+
+  val dataElements: Flow[ByteString, JsObject, NotUsed] =
+    JsonReader
+      .select(pathToNestedData)
+      .map(byteString => Json.parse(byteString.toArray).as[JsObject])
+      .log(loggerName)
+      .withAttributes(
+        Attributes
+          .logLevels(
+            onElement = onElement,
+            onFinish = onFinish,
+            onFailure = onFailure
+          )
+      )
+
+}

--- a/app/data/config/StreamLoggingConfig.scala
+++ b/app/data/config/StreamLoggingConfig.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data.config
+
+import akka.event.Logging
+import akka.event.Logging.LogLevel
+import javax.inject.Inject
+import play.api.Configuration
+
+class StreamLoggingConfig @Inject() (config: Configuration) {
+
+  private val pathToConfig: String = "data.stream.logging"
+
+  /**
+    * Configuration for the logging level of AkkaStream components. This allows for global
+    * application configuration, or stream component specific configuration.
+    *
+    * @param streamComponentName if provided, this will be used for this component over the
+    *                            global value at `data.stream.logging.onElement.level`,
+    *                            `data.stream.logging.onFinish.level` or
+    *                            `data.stream.logging.onFailure.level`
+    *
+    * @return (onElement, onFinish, onFailure)
+    */
+  def loggingConfig(streamComponentName: Option[String] = None): (LogLevel, LogLevel, LogLevel) =
+    (
+      onElement(streamComponentName),
+      onFinish(streamComponentName),
+      onFailure(streamComponentName)
+    )
+
+  private def streamLoggingConfigPath(streamComponentName: Option[String]): String =
+    streamComponentName.fold(pathToConfig) {
+      name =>
+        s"$pathToConfig.$name"
+    }
+
+  private def onElement(streamComponentName: Option[String]): LogLevel =
+    config
+      .getOptional[LogLevel](streamLoggingConfigPath(streamComponentName) + ".onElement")
+      .getOrElse(Logging.levelFor("off").get)
+
+  private def onFinish(streamComponentName: Option[String]): LogLevel =
+    config
+      .getOptional[LogLevel](streamLoggingConfigPath(streamComponentName) + ".onFinish")
+      .getOrElse(Logging.levelFor("off").get)
+
+  private def onFailure(streamComponentName: Option[String]): LogLevel =
+    config
+      .getOptional[LogLevel](streamLoggingConfigPath(streamComponentName) + ".onFailure")
+      .getOrElse(Logging.levelFor("warn").get)
+
+}

--- a/app/data/config/StreamLoggingConfig.scala
+++ b/app/data/config/StreamLoggingConfig.scala
@@ -21,9 +21,7 @@ import akka.event.Logging.LogLevel
 import javax.inject.Inject
 import play.api.Configuration
 
-class StreamLoggingConfig @Inject() (config: Configuration) {
-
-  private val pathToConfig: String = "data.stream.logging"
+trait StreamLoggingConfig {
 
   /**
     * Configuration for the logging level of AkkaStream components. This allows for global
@@ -36,7 +34,15 @@ class StreamLoggingConfig @Inject() (config: Configuration) {
     *
     * @return (onElement, onFinish, onFailure)
     */
-  def loggingConfig(streamComponentName: Option[String] = None): (LogLevel, LogLevel, LogLevel) =
+  def loggingConfig(streamComponentName: Option[String] = None): (LogLevel, LogLevel, LogLevel)
+
+}
+
+class StreamLoggingConfigImpl @Inject() (config: Configuration) extends StreamLoggingConfig {
+
+  private val pathToConfig: String = "data.stream.logging"
+
+  override def loggingConfig(streamComponentName: Option[String] = None): (LogLevel, LogLevel, LogLevel) =
     (
       onElement(streamComponentName),
       onFinish(streamComponentName),

--- a/app/data/config/package.scala
+++ b/app/data/config/package.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data
+
+import akka.event.Logging
+import akka.event.Logging.LogLevel
+import play.api.ConfigLoader
+import play.api.Configuration
+
+package object config {
+
+  implicit val configLoader: ConfigLoader[LogLevel] =
+    ConfigLoader {
+      config => prefix =>
+        val service = Configuration(config).get[Configuration](prefix)
+        val value   = service.get[String]("level")
+
+        Logging.levelFor(value).get
+    }
+
+}

--- a/app/data/connector/RefDataConnector.scala
+++ b/app/data/connector/RefDataConnector.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data.connector
+
+import akka.util.ByteString
+import models.ListName
+
+import scala.concurrent.Future
+
+private[data] trait RefDataConnector {
+  def get(listName: ListName): Future[ByteString]
+}

--- a/app/data/connector/RefDataConnector.scala
+++ b/app/data/connector/RefDataConnector.scala
@@ -22,5 +22,5 @@ import models.ListName
 import scala.concurrent.Future
 
 private[data] trait RefDataConnector {
-  def get(listName: ListName): Future[ByteString]
+  def get(listName: ListName): Future[Option[ByteString]]
 }

--- a/app/logging/Logging.scala
+++ b/app/logging/Logging.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import play.api.Logger
+
+trait Logging {
+
+  protected val logger: Logger = Logger(s"application.${this.getClass.getCanonicalName}")
+
+}

--- a/app/logging/LoggingModule.scala
+++ b/app/logging/LoggingModule.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import com.google.inject.AbstractModule
+import data.config.StreamLoggingConfig
+import data.config.StreamLoggingConfigImpl
+
+class LoggingModule extends AbstractModule {
+
+  override def configure(): Unit =
+    bind(classOf[StreamLoggingConfig]).to(classOf[StreamLoggingConfigImpl]).asEagerSingleton()
+}

--- a/app/logging/StreamLoggerAdapter.scala
+++ b/app/logging/StreamLoggerAdapter.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.event.LoggingAdapter
+
+trait StreamLoggerAdapter {
+
+  final val loggerName: String = s"application.${this.getClass.getCanonicalName}"
+
+  implicit def adapter(implicit actorSystem: ActorSystem): LoggingAdapter =
+    Logging(actorSystem, loggerName)
+
+}

--- a/app/models/ListName.scala
+++ b/app/models/ListName.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+case class ListName(listName: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -49,6 +49,7 @@ play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.http.JsonErrorHandler"
 
 play.modules.enabled += "config.Modules"
 play.modules.enabled += "api.services.ServicesModules"
+play.modules.enabled += "logging.LoggingModule"
 
 # Session Timeout
 # ~~~~

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,11 +5,12 @@ object AppDependencies {
   private val catsVersion = "2.1.1"
 
   val compile = Seq(
-    "uk.gov.hmrc"       %% "bootstrap-backend-play-27"       % "2.25.0",
-    "org.reactivemongo" %% "play2-reactivemongo"             % "0.20.11-play27",
-    "com.typesafe.play" %% "play-iteratees"                  % "2.6.1",
-    "com.typesafe.play" %% "play-iteratees-reactive-streams" % "2.6.1",
-    "org.typelevel"     %% "cats-core"                       % catsVersion
+    "uk.gov.hmrc"        %% "bootstrap-backend-play-27"          % "2.25.0",
+    "org.reactivemongo"  %% "play2-reactivemongo"                % "0.20.11-play27",
+    "com.typesafe.play"  %% "play-iteratees"                     % "2.6.1",
+    "com.typesafe.play"  %% "play-iteratees-reactive-streams"    % "2.6.1",
+    "org.typelevel"      %% "cats-core"                          % catsVersion,
+    "com.lightbend.akka" %% "akka-stream-alpakka-json-streaming" % "2.0.2"
   )
 
   val test = Seq(

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -17,7 +17,8 @@
 package base
 
 import org.scalatest.OptionValues
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 
-trait SpecBase extends AnyFreeSpec with Matchers with OptionValues with TestWithMocking
+trait SpecBase extends AnyFreeSpec with Matchers with OptionValues with TestWithMocking with ScalaFutures

--- a/test/data/RefDataSourceSpec.scala
+++ b/test/data/RefDataSourceSpec.scala
@@ -16,9 +16,10 @@
 
 package data
 
+import akka.NotUsed
 import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
-import akka.util.ByteString
 import base.SpecBase
 import data.connector.RefDataConnector
 import models.ListName
@@ -30,6 +31,7 @@ import play.api.libs.json.OWrites
 import data.ReferenceDataJsonProjectionSpec.formatAsReferenceDataJson
 import logging.TestStreamLoggingConfig
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class RefDataSourceSpec extends SpecBase {
@@ -47,11 +49,11 @@ class RefDataSourceSpec extends SpecBase {
 
     val mockDataConnector = mock[RefDataConnector]
 
-    when(mockDataConnector.get(eqTo(listName))).thenReturn(Future.successful(testData))
+    when(mockDataConnector.get(eqTo(listName))).thenReturn(Future.successful(Some(testData)))
 
     val referenceDataJsonProjection = new ReferenceDataJsonProjection(TestStreamLoggingConfig)
     val sut                         = new RefDataSource(mockDataConnector, referenceDataJsonProjection)
-    val source                      = sut(listName)
+    val source                      = sut(listName).futureValue.value
 
     source
       .runWith(TestSink.probe[JsObject])

--- a/test/data/RefDataSourceSpec.scala
+++ b/test/data/RefDataSourceSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data
+
+import akka.actor.ActorSystem
+import akka.stream.testkit.scaladsl.TestSink
+import akka.util.ByteString
+import base.SpecBase
+import data.connector.RefDataConnector
+import models.ListName
+import org.mockito.ArgumentMatchers.{eq => eqTo}
+import org.mockito.Mockito._
+import play.api.libs.json.JsObject
+import play.api.libs.json.Json
+import play.api.libs.json.OWrites
+import data.ReferenceDataJsonProjectionSpec.formatAsReferenceDataJson
+import logging.TestStreamLoggingConfig
+
+import scala.concurrent.Future
+
+class RefDataSourceSpec extends SpecBase {
+
+  implicit lazy val actorSystem: ActorSystem = ActorSystem()
+
+  "reads the returned json and returns the nested sequence of values in `data`" in {
+    case class TestObject(int: Int)
+    implicit val owrites: OWrites[TestObject] = o => Json.obj("int" -> o.int)
+
+    val testData     = formatAsReferenceDataJson(Seq(TestObject(1), TestObject(2)))
+    val expectedData = List(Json.obj("int" -> 1), Json.obj("int" -> 2))
+
+    val listName = ListName("TestObject")
+
+    val mockDataConnector = mock[RefDataConnector]
+
+    when(mockDataConnector.get(eqTo(listName))).thenReturn(Future.successful(testData))
+
+    val referenceDataJsonProjection = new ReferenceDataJsonProjection(TestStreamLoggingConfig)
+    val sut                         = new RefDataSource(mockDataConnector, referenceDataJsonProjection)
+    val source                      = sut(listName)
+
+    source
+      .runWith(TestSink.probe[JsObject])
+      .request(2)
+      .expectNextN(all = expectedData)
+      .expectComplete()
+  }
+
+}

--- a/test/data/ReferenceDataJsonProjectionSpec.scala
+++ b/test/data/ReferenceDataJsonProjectionSpec.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data
+
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.stream.scaladsl.Keep
+import akka.stream.testkit.scaladsl.TestSink
+import akka.stream.testkit.scaladsl.TestSource
+import akka.util.ByteString
+import base.SpecBase
+import data.config.StreamLoggingConfig
+import play.api.libs.json.JsObject
+import play.api.libs.json.Json
+import play.api.libs.json.OWrites
+import play.api.libs.json.Writes
+import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers._
+
+class ReferenceDataJsonProjectionSpec extends SpecBase {
+  import ReferenceDataJsonProjectionSpec._
+
+  val mockStreamLoggingConfig: StreamLoggingConfig = mock[StreamLoggingConfig]
+  when(mockStreamLoggingConfig.loggingConfig(any())).thenReturn(
+    (Logging.levelFor("off").get, Logging.levelFor("off").get, Logging.levelFor("error").get)
+  )
+
+  implicit lazy val actorSystem: ActorSystem = ActorSystem()
+
+  val referenceDataJsonProjection = new ReferenceDataJsonProjection(mockStreamLoggingConfig)
+
+  "projects and returns all values in the nested sequence of values in the `data` array" in {
+    implicit val owrites: OWrites[JsObject] = identity[JsObject]
+
+    val expectedData = List(Json.obj("int" -> 1), Json.obj("int" -> 2))
+    val testData     = formatAsReferenceDataJson(expectedData)
+
+    val (pub, sub) =
+      TestSource
+        .probe[ByteString]
+        .via(referenceDataJsonProjection.dataElements)
+        .toMat(TestSink.probe[JsObject])(Keep.both)
+        .run()
+
+    sub.request(expectedData.length + 1)
+    pub.sendNext(testData)
+    sub.expectNextN(expectedData)
+  }
+
+  "stream returns an error when values in the `data` array are not objects" in {
+
+    val expectedData = List("one")
+    val testData     = formatAsReferenceDataJson(expectedData)
+
+    val (pub, sub) =
+      TestSource
+        .probe[ByteString]
+        .via(referenceDataJsonProjection.dataElements)
+        .toMat(TestSink.probe[JsObject])(Keep.both)
+        .run()
+
+    sub.request(expectedData.length + 1)
+    pub.sendNext(testData)
+    val error = sub.expectError()
+
+    error.getMessage().contains("JsResultException") mustEqual true
+  }
+
+}
+
+object ReferenceDataJsonProjectionSpec {
+
+  def formatAsReferenceDataJson[A: Writes](data: Seq[A]): ByteString =
+    ByteString(
+      Json
+        .obj(
+          "_links" -> Json.obj("self" -> "foo"),
+          "meta"   -> Json.obj("meta1" -> "meta1Value"),
+          "id"     -> "idValue",
+          "data"   -> Json.toJson(data)
+        )
+        .toString()
+    )
+}

--- a/test/data/ReferenceDataJsonProjectionSpec.scala
+++ b/test/data/ReferenceDataJsonProjectionSpec.scala
@@ -17,20 +17,16 @@
 package data
 
 import akka.actor.ActorSystem
-import akka.event.Logging
 import akka.stream.scaladsl.Keep
 import akka.stream.testkit.scaladsl.TestSink
 import akka.stream.testkit.scaladsl.TestSource
 import akka.util.ByteString
 import base.SpecBase
-import data.config.StreamLoggingConfig
 import logging.TestStreamLoggingConfig
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
 import play.api.libs.json.OWrites
 import play.api.libs.json.Writes
-import org.mockito.Mockito._
-import org.mockito.ArgumentMatchers._
 
 class ReferenceDataJsonProjectionSpec extends SpecBase {
   import ReferenceDataJsonProjectionSpec._

--- a/test/data/ReferenceDataJsonProjectionSpec.scala
+++ b/test/data/ReferenceDataJsonProjectionSpec.scala
@@ -24,6 +24,7 @@ import akka.stream.testkit.scaladsl.TestSource
 import akka.util.ByteString
 import base.SpecBase
 import data.config.StreamLoggingConfig
+import logging.TestStreamLoggingConfig
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
 import play.api.libs.json.OWrites
@@ -34,14 +35,9 @@ import org.mockito.ArgumentMatchers._
 class ReferenceDataJsonProjectionSpec extends SpecBase {
   import ReferenceDataJsonProjectionSpec._
 
-  val mockStreamLoggingConfig: StreamLoggingConfig = mock[StreamLoggingConfig]
-  when(mockStreamLoggingConfig.loggingConfig(any())).thenReturn(
-    (Logging.levelFor("off").get, Logging.levelFor("off").get, Logging.levelFor("error").get)
-  )
-
   implicit lazy val actorSystem: ActorSystem = ActorSystem()
 
-  val referenceDataJsonProjection = new ReferenceDataJsonProjection(mockStreamLoggingConfig)
+  val referenceDataJsonProjection = new ReferenceDataJsonProjection(TestStreamLoggingConfig)
 
   "projects and returns all values in the nested sequence of values in the `data` array" in {
     implicit val owrites: OWrites[JsObject] = identity[JsObject]

--- a/test/logging/TestLoggingModule.scala
+++ b/test/logging/TestLoggingModule.scala
@@ -16,7 +16,8 @@
 
 package logging
 
-import akka.event.Logging
+import akka.event.Logging.LogLevel
+import akka.event.{Logging => AkkaLogging}
 import com.google.inject.AbstractModule
 import data.config.StreamLoggingConfig
 
@@ -39,6 +40,6 @@ object TestStreamLoggingConfig extends StreamLoggingConfig {
     *
     * @return (onElement, onFinish, onFailure)
     */
-  override def loggingConfig(streamComponentName: Option[String]): (Logging.LogLevel, Logging.LogLevel, Logging.LogLevel) =
-    (Logging.levelFor("off").get, Logging.levelFor("off").get, Logging.levelFor("error").get)
+  override def loggingConfig(streamComponentName: Option[String]): (LogLevel, LogLevel, LogLevel) =
+    (AkkaLogging.levelFor("off").get, AkkaLogging.levelFor("off").get, AkkaLogging.levelFor("off").get)
 }

--- a/test/logging/TestLoggingModule.scala
+++ b/test/logging/TestLoggingModule.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import akka.event.Logging
+import com.google.inject.AbstractModule
+import data.config.StreamLoggingConfig
+
+class TestLoggingModule extends AbstractModule {
+
+  override def configure(): Unit =
+    bind(classOf[StreamLoggingConfig]).toInstance(TestStreamLoggingConfig)
+}
+
+object TestStreamLoggingConfig extends StreamLoggingConfig {
+
+  /**
+    * Configuration for the logging level of AkkaStream components. This allows for global
+    * application configuration, or stream component specific configuration.
+    *
+    * @param streamComponentName if provided, this will be used for this component over the
+    *                            global value at `data.stream.logging.onElement.level`,
+    *                            `data.stream.logging.onFinish.level` or
+    *                            `data.stream.logging.onFailure.level`
+    *
+    * @return (onElement, onFinish, onFailure)
+    */
+  override def loggingConfig(streamComponentName: Option[String]): (Logging.LogLevel, Logging.LogLevel, Logging.LogLevel) =
+    (Logging.levelFor("off").get, Logging.levelFor("off").get, Logging.levelFor("error").get)
+}

--- a/test/resources/test.application.conf
+++ b/test/resources/test.application.conf
@@ -14,6 +14,9 @@
 
 include "application.conf"
 
+play.modules.disabled += "logging.LoggingModule"
+play.modules.enabled += "logging.TestLoggingModule"
+
 mongo-async-driver {
   akka {
     log-dead-letters-during-shutdown = off


### PR DESCRIPTION
- Define interface for the data package.
- Add traits for classical play logging and for AkkaStream logging.
- Allow for configuration of the logging level by config.
- Using Alpakka, define a flow that turns a ref data response into a stream of JsObjects.
- Add override log levels in test for streams
- Add interface for connector that external calls for reference data.
- Combine ref data connector and flow that project data elements into new flow
- Change RefDataConnector to return Optional value.
- Split reads and writes for models.

Outstanding:
- implementation of the connector call to the `customs reference data` service
- transformation of the data into form that conforms to API of the service
- integration with the `api`
