### PR TITLE
Implement mechanism to fetch data from Customs reference data for known lists and allow for encoding of json transformation of data

### DIFF
--- a/app/data/DataRetrieval.scala
+++ b/app/data/DataRetrieval.scala
@@ -16,13 +16,14 @@
 
 package data
 
-import models.ListName
-import play.api.libs.json.Reads
+import data.transform.Transformation
+import models.ReferenceDataList
+import play.api.libs.json.JsObject
 
 import scala.concurrent.Future
 
 trait DataRetrieval {
 
-  def getList[A: Reads](list: ListName): Future[Seq[A]]
+  def getList[A <: ReferenceDataList](list: A)(implicit transformation: Transformation[A]): Future[Seq[JsObject]]
 
 }

--- a/app/data/RefDataSource.scala
+++ b/app/data/RefDataSource.scala
@@ -32,14 +32,9 @@ private[data] class RefDataSource @Inject() (
   referenceDataJsonProjection: ReferenceDataJsonProjection
 )(implicit ec: ExecutionContext) {
 
-  private def jsonByteStringToDataElements(jsonByteString: ByteString): Source[JsObject, NotUsed] =
-    Source
-      .single(jsonByteString)
-      .via(referenceDataJsonProjection.dataElements)
-
-  def apply(listName: ReferenceDataList): Future[Option[Source[JsObject, NotUsed]]] =
+  def apply(listName: ReferenceDataList): Future[Option[Source[JsObject, _]]] =
     refDataConnector
-      .get(listName)
-      .map(_.map(jsonByteStringToDataElements))
+      .getAsSource(listName)
+      .map(_.map(_.via(referenceDataJsonProjection.dataElements)))
 
 }

--- a/app/data/RefDataSource.scala
+++ b/app/data/RefDataSource.scala
@@ -21,7 +21,7 @@ import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import data.connector.RefDataConnector
 import javax.inject.Inject
-import models.ListName
+import models.ReferenceDataList
 import play.api.libs.json.JsObject
 
 import scala.concurrent.ExecutionContext
@@ -37,7 +37,7 @@ private[data] class RefDataSource @Inject() (
       .single(jsonByteString)
       .via(referenceDataJsonProjection.dataElements)
 
-  def apply(listName: ListName): Future[Option[Source[JsObject, NotUsed]]] =
+  def apply(listName: ReferenceDataList): Future[Option[Source[JsObject, NotUsed]]] =
     refDataConnector
       .get(listName)
       .map(_.map(jsonByteStringToDataElements))

--- a/app/data/connector/ConnectorConfig.scala
+++ b/app/data/connector/ConnectorConfig.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data.connector
+
+import javax.inject.Inject
+import models.config.Service
+import play.api.Configuration
+
+class ConnectorConfig @Inject() (config: Configuration) {
+
+  val customsReferenceData: Service =
+    config.get[Service]("microservice.services.customsReferenceData")
+
+}

--- a/app/data/connector/ConnectorConfig.scala
+++ b/app/data/connector/ConnectorConfig.scala
@@ -20,7 +20,7 @@ import javax.inject.Inject
 import models.config.Service
 import play.api.Configuration
 
-class ConnectorConfig @Inject() (config: Configuration) {
+private[connector] class ConnectorConfig @Inject() (config: Configuration) {
 
   val customsReferenceData: Service =
     config.get[Service]("microservice.services.customsReferenceData")

--- a/app/data/connector/ConnectorModules.scala
+++ b/app/data/connector/ConnectorModules.scala
@@ -20,7 +20,10 @@ import com.google.inject.AbstractModule
 
 class ConnectorModules extends AbstractModule {
 
-  override def configure(): Unit =
+  override def configure(): Unit = {
     bind(classOf[RefDataConnector]).to(classOf[RefDataConnectorImpl])
+    bind(classOf[ConnectorConfig]).asEagerSingleton()
+
+  }
 
 }

--- a/app/data/connector/ConnectorModules.scala
+++ b/app/data/connector/ConnectorModules.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data.connector
+
+import com.google.inject.AbstractModule
+
+class ConnectorModules extends AbstractModule {
+
+  override def configure(): Unit =
+    bind(classOf[RefDataConnector]).to(classOf[RefDataConnectorImpl])
+
+}

--- a/app/data/connector/RefDataConnector.scala
+++ b/app/data/connector/RefDataConnector.scala
@@ -17,10 +17,10 @@
 package data.connector
 
 import akka.util.ByteString
-import models.ListName
+import models.ReferenceDataList
 
 import scala.concurrent.Future
 
 private[data] trait RefDataConnector {
-  def get(listName: ListName): Future[Option[ByteString]]
+  def get(listName: ReferenceDataList): Future[Option[ByteString]]
 }

--- a/app/data/connector/RefDataConnector.scala
+++ b/app/data/connector/RefDataConnector.scala
@@ -16,6 +16,7 @@
 
 package data.connector
 
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import models.ReferenceDataList
 
@@ -23,4 +24,6 @@ import scala.concurrent.Future
 
 private[data] trait RefDataConnector {
   def get(listName: ReferenceDataList): Future[Option[ByteString]]
+
+  def getAsSource(listName: ReferenceDataList): Future[Option[Source[ByteString, _]]]
 }

--- a/app/data/connector/RefDataConnectorImpl.scala
+++ b/app/data/connector/RefDataConnectorImpl.scala
@@ -50,7 +50,7 @@ private[connector] class RefDataConnectorImpl @Inject() (ws: WSClient, connector
       lists = response.json.as[ReferenceDataLists]
       listRelativePath <- OptionT.fromOption[Future](lists.getPath(listName))
       listUrl = connectorConfig.customsReferenceData.fromRelativePath(listRelativePath)
-      listData <- OptionT.liftF(ws.url(listUrl).get)
+      listData <- OptionT.liftF(ws.url(listUrl).stream())
     } yield listData.bodyAsSource).value
   }
 

--- a/app/data/connector/RefDataConnectorImpl.scala
+++ b/app/data/connector/RefDataConnectorImpl.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data.connector
+
+import akka.util.ByteString
+import cats.data._
+import cats.implicits._
+import javax.inject.Inject
+import models.ReferenceDataList
+import play.api.libs.ws.WSClient
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+private[connector] class RefDataConnectorImpl @Inject() (ws: WSClient, connectorConfig: ConnectorConfig)(implicit ec: ExecutionContext)
+    extends RefDataConnector {
+
+  override def get(listName: ReferenceDataList): Future[Option[ByteString]] = {
+    val url = connectorConfig.customsReferenceData.urlWithBaseUrl("/lists")
+
+    (for {
+      response <- OptionT.liftF(ws.url(url).get)
+      lists = response.json.as[ReferenceDataLists]
+      listRelativePath <- OptionT.fromOption[Future](lists.getPath(listName))
+      listUrl = connectorConfig.customsReferenceData.fromRelativePath(listRelativePath)
+      listData <- OptionT.liftF(ws.url(listUrl).get)
+    } yield listData.bodyAsBytes).value
+  }
+
+}

--- a/app/data/connector/ReferenceDataLists.scala
+++ b/app/data/connector/ReferenceDataLists.scala
@@ -20,14 +20,14 @@ import models.ReferenceDataList
 import play.api.libs.json.Reads
 import play.api.libs.json._
 
-case class ReferenceDataLists(listPathMappings: Map[ReferenceDataList, String]) {
+private[data] case class ReferenceDataLists(listPathMappings: Map[ReferenceDataList, String]) {
 
   def getPath(listName: ReferenceDataList): Option[String] =
     listPathMappings.get(listName)
 
 }
 
-object ReferenceDataLists {
+private[data] object ReferenceDataLists {
 
   private val hrefTransform: Reads[JsString] =
     (__ \ "href").json.pick[JsString]

--- a/app/data/connector/ReferenceDataLists.scala
+++ b/app/data/connector/ReferenceDataLists.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data.connector
+
+import models.ReferenceDataList
+import play.api.libs.json.Reads
+import play.api.libs.json._
+
+case class ReferenceDataLists(listPathMappings: Map[ReferenceDataList, String]) {
+
+  def getPath(listName: ReferenceDataList): Option[String] =
+    listPathMappings.get(listName)
+
+}
+
+object ReferenceDataLists {
+
+  private val hrefTransform: Reads[JsString] =
+    (__ \ "href").json.pick[JsString]
+
+  implicit val asdf: Reads[ReferenceDataLists] =
+    implicitly[Reads[Map[String, JsValue]]]
+      .map {
+        _.filterKeys(_ != "_self")
+          .flatMap {
+            case (listName, path) =>
+              ReferenceDataList.mappings
+                .get(listName)
+                .map(refDatList => (refDatList, path.transform(hrefTransform).get.value))
+          }
+
+      }
+      .map(ReferenceDataLists(_))
+
+}

--- a/app/data/transform/Transformation.scala
+++ b/app/data/transform/Transformation.scala
@@ -14,6 +14,24 @@
  * limitations under the License.
  */
 
-package models
+package data.transform
 
-case class ListName(listName: String)
+import play.api.libs.json.JsObject
+import play.api.libs.json.Reads
+
+trait Transformation[A] {
+
+  def transformation: Reads[JsObject]
+
+}
+
+object Transformation {
+
+  def apply[A: Transformation]: Transformation[A] = implicitly[Transformation[A]]
+
+  def fromReads[A](reads: Reads[JsObject]): Transformation[A] =
+    new Transformation[A] {
+      override def transformation: Reads[JsObject] = reads
+    }
+
+}

--- a/app/data/transform/TransformationValues.scala
+++ b/app/data/transform/TransformationValues.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data.transform
+
+import play.api.libs.json._
+import play.api.libs.json.Reads._
+import play.api.libs.functional.syntax._
+import models.CountryCodesFullList
+
+trait TransformationValues {
+
+  val englishDescription: Reads[JsValue] =
+    (__ \ "description" \ "en").json.pick
+
+  implicit val transformationCountryCodesFullList: Transformation[CountryCodesFullList.type] =
+    Transformation
+      .fromReads(
+        (
+          (__ \ "code").json.copyFrom((__ \ "countryCode").json.pick) and
+            (__ \ "state").json.pickBranch and
+            (__ \ "activeFrom").json.pickBranch and
+            (__ \ "description").json.copyFrom(englishDescription)
+        ).reduce andThen (
+          (__ \ "activeFrom").json.prune
+        )
+      )
+
+}

--- a/app/models/ReferenceDataList.scala
+++ b/app/models/ReferenceDataList.scala
@@ -19,7 +19,7 @@ package models
 import cats.data.NonEmptyList
 import play.api.mvc.PathBindable
 
-abstract class ReferenceDataList(val listName: String)
+sealed abstract class ReferenceDataList(val listName: String)
 
 object ReferenceDataList {
 

--- a/app/models/ReferenceDataList.scala
+++ b/app/models/ReferenceDataList.scala
@@ -16,22 +16,25 @@
 
 package models
 
+import cats.data.NonEmptyList
 import play.api.mvc.PathBindable
 
 abstract class ReferenceDataList(val listName: String)
 
 object ReferenceDataList {
 
-  val values: Map[String, ReferenceDataList] =
-    Seq(
-      AdditionalInformationList,
-      AdditionalInformationList
-    ).map(x => x.listName -> x).toMap
+  val values: NonEmptyList[AdditionalInformationList.type] = NonEmptyList.of(
+    AdditionalInformationList,
+    AdditionalInformationList
+  )
+
+  val mappings: Map[String, ReferenceDataList] =
+    values.map(x => x.listName -> x).toList.toMap
 
   implicit val pathBindable: PathBindable[ReferenceDataList] = new PathBindable[ReferenceDataList] {
 
     override def bind(key: String, value: String): Either[String, ReferenceDataList] =
-      values.get(value).toRight(s"Unknown reference data list name : $value")
+      mappings.get(value).toRight(s"Unknown reference data list name : $value")
 
     override def unbind(key: String, value: ReferenceDataList): String = value.listName
   }

--- a/app/models/ReferenceDataList.scala
+++ b/app/models/ReferenceDataList.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.mvc.PathBindable
+
+abstract class ReferenceDataList(val listName: String)
+
+object ReferenceDataList {
+
+  val values: Map[String, ReferenceDataList] =
+    Seq(
+      AdditionalInformationList,
+      AdditionalInformationList
+    ).map(x => x.listName -> x).toMap
+
+  implicit val pathBindable: PathBindable[ReferenceDataList] = new PathBindable[ReferenceDataList] {
+
+    override def bind(key: String, value: String): Either[String, ReferenceDataList] =
+      values.get(value).toRight(s"Unknown reference data list name : $value")
+
+    override def unbind(key: String, value: ReferenceDataList): String = value.listName
+  }
+
+}
+
+object AdditionalInformationList extends ReferenceDataList("AdditionalInformationIdCommon")
+object CircumstanceIndicatorList extends ReferenceDataList("SpecificCircumstanceIndicator")

--- a/app/models/ReferenceDataList.scala
+++ b/app/models/ReferenceDataList.scala
@@ -23,10 +23,11 @@ abstract class ReferenceDataList(val listName: String)
 
 object ReferenceDataList {
 
-  val values: NonEmptyList[AdditionalInformationList.type] = NonEmptyList.of(
-    AdditionalInformationList,
-    AdditionalInformationList
-  )
+  val values: NonEmptyList[ReferenceDataList] =
+    NonEmptyList.of(
+      AdditionalInformationList,
+      CircumstanceIndicatorList
+    )
 
   val mappings: Map[String, ReferenceDataList] =
     values.map(x => x.listName -> x).toList.toMap

--- a/app/models/ReferenceDataList.scala
+++ b/app/models/ReferenceDataList.scala
@@ -26,7 +26,8 @@ object ReferenceDataList {
   val values: NonEmptyList[ReferenceDataList] =
     NonEmptyList.of(
       AdditionalInformationList,
-      CircumstanceIndicatorList
+      CircumstanceIndicatorList,
+      CountryCodesFullList
     )
 
   val mappings: Map[String, ReferenceDataList] =
@@ -44,3 +45,4 @@ object ReferenceDataList {
 
 object AdditionalInformationList extends ReferenceDataList("AdditionalInformationIdCommon")
 object CircumstanceIndicatorList extends ReferenceDataList("SpecificCircumstanceIndicator")
+object CountryCodesFullList      extends ReferenceDataList("CountryCodesFullList")

--- a/app/models/config/Service.scala
+++ b/app/models/config/Service.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.config
+
+import play.api.ConfigLoader
+import play.api.Configuration
+
+final case class Service(host: String, port: String, protocol: String, startUrl: String) {
+  private val domain: String = s"$protocol://$host:$port"
+
+  def fromRelativePath(path: String): String =
+    if (path.nonEmpty && path.head == '/')
+      domain + path
+    else
+      domain + "/" + path
+
+  def urlWithBaseUrl(path: String): String =
+    if (path.nonEmpty && path.head == '/')
+      baseUrl + path
+    else
+      baseUrl + "/" + path
+
+  def baseUrl: String =
+    s"$domain/$startUrl"
+
+  override def toString: String =
+    baseUrl
+
+}
+
+object Service {
+
+  implicit lazy val configLoader: ConfigLoader[Service] = ConfigLoader {
+    config => prefix =>
+      val service  = Configuration(config).get[Configuration](prefix)
+      val host     = service.get[String]("host")
+      val port     = service.get[String]("port")
+      val protocol = service.get[String]("protocol")
+      val startUrl = service.get[String]("startUrl")
+      Service(host, port, protocol, startUrl)
+  }
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -50,6 +50,7 @@ play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.http.JsonErrorHandler"
 play.modules.enabled += "config.Modules"
 play.modules.enabled += "api.services.ServicesModules"
 play.modules.enabled += "logging.LoggingModule"
+play.modules.enabled += "data.connector.ConnectorModules"
 
 # Session Timeout
 # ~~~~

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -159,6 +159,14 @@ microservice {
   }
 
   services {
+    customsReferenceData {
+      protocol = http
+      host = localhost
+      port = 9492
+      startUrl = "customs-reference-data"
+    }
+
+
     auth {
       host = localhost
       port = 8500

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -24,7 +24,8 @@ object AppDependencies {
     "com.typesafe.akka"      %% "akka-stream-testkit"      % "2.6.10",
     "com.typesafe.akka"      %% "akka-slf4j"               % "2.6.10",
     "org.pegdown"            % "pegdown"                   % "1.6.0",
-    "com.vladsch.flexmark"   % "flexmark-all"              % "0.35.10"
+    "com.vladsch.flexmark"   % "flexmark-all"              % "0.35.10",
+    "com.github.tomakehurst" % "wiremock-standalone"       % "2.27.1",
   ).map(_ % "test, it")
 
 }

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -16,9 +16,11 @@
 
 package base
 
+import org.scalatest.EitherValues
 import org.scalatest.OptionValues
+import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 
-trait SpecBase extends AnyFreeSpec with Matchers with OptionValues with TestWithMocking with ScalaFutures
+trait SpecBase extends AnyFreeSpec with Matchers with OptionValues with TestWithMocking with ScalaFutures with IntegrationPatience with EitherValues

--- a/test/data/RefDataSourceSpec.scala
+++ b/test/data/RefDataSourceSpec.scala
@@ -17,6 +17,7 @@
 package data
 
 import akka.actor.ActorSystem
+import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
 import base.SpecBase
 import data.ReferenceDataJsonProjectionSpec.formatAsReferenceDataByteString
@@ -46,8 +47,8 @@ class RefDataSourceSpec extends SpecBase {
     val listName = ReferenceDataList.values.head
 
     val mockDataConnector = mock[RefDataConnector]
-
     when(mockDataConnector.get(eqTo(listName))).thenReturn(Future.successful(Some(testData)))
+    when(mockDataConnector.getAsSource(eqTo(listName))).thenReturn(Future.successful(Some(Source.single(testData))))
 
     val referenceDataJsonProjection = new ReferenceDataJsonProjection(TestStreamLoggingConfig)
     val sut                         = new RefDataSource(mockDataConnector, referenceDataJsonProjection)

--- a/test/data/RefDataSourceSpec.scala
+++ b/test/data/RefDataSourceSpec.scala
@@ -28,7 +28,7 @@ import org.mockito.Mockito._
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
 import play.api.libs.json.OWrites
-import data.ReferenceDataJsonProjectionSpec.formatAsReferenceDataJson
+import data.ReferenceDataJsonProjectionSpec.formatAsReferenceDataByteString
 import logging.TestStreamLoggingConfig
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -42,7 +42,7 @@ class RefDataSourceSpec extends SpecBase {
     case class TestObject(int: Int)
     implicit val owrites: OWrites[TestObject] = o => Json.obj("int" -> o.int)
 
-    val testData     = formatAsReferenceDataJson(Seq(TestObject(1), TestObject(2)))
+    val testData     = formatAsReferenceDataByteString(Seq(TestObject(1), TestObject(2)))
     val expectedData = List(Json.obj("int" -> 1), Json.obj("int" -> 2))
 
     val listName = new ReferenceDataList("TestObject") {}

--- a/test/data/RefDataSourceSpec.scala
+++ b/test/data/RefDataSourceSpec.scala
@@ -22,7 +22,7 @@ import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
 import base.SpecBase
 import data.connector.RefDataConnector
-import models.ListName
+import models.ReferenceDataList
 import org.mockito.ArgumentMatchers.{eq => eqTo}
 import org.mockito.Mockito._
 import play.api.libs.json.JsObject
@@ -45,7 +45,7 @@ class RefDataSourceSpec extends SpecBase {
     val testData     = formatAsReferenceDataJson(Seq(TestObject(1), TestObject(2)))
     val expectedData = List(Json.obj("int" -> 1), Json.obj("int" -> 2))
 
-    val listName = ListName("TestObject")
+    val listName = new ReferenceDataList("TestObject") {}
 
     val mockDataConnector = mock[RefDataConnector]
 

--- a/test/data/RefDataSourceSpec.scala
+++ b/test/data/RefDataSourceSpec.scala
@@ -16,20 +16,18 @@
 
 package data
 
-import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
 import base.SpecBase
+import data.ReferenceDataJsonProjectionSpec.formatAsReferenceDataByteString
 import data.connector.RefDataConnector
+import logging.TestStreamLoggingConfig
 import models.ReferenceDataList
 import org.mockito.ArgumentMatchers.{eq => eqTo}
 import org.mockito.Mockito._
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json
 import play.api.libs.json.OWrites
-import data.ReferenceDataJsonProjectionSpec.formatAsReferenceDataByteString
-import logging.TestStreamLoggingConfig
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -45,7 +43,7 @@ class RefDataSourceSpec extends SpecBase {
     val testData     = formatAsReferenceDataByteString(Seq(TestObject(1), TestObject(2)))
     val expectedData = List(Json.obj("int" -> 1), Json.obj("int" -> 2))
 
-    val listName = new ReferenceDataList("TestObject") {}
+    val listName = ReferenceDataList.values.head
 
     val mockDataConnector = mock[RefDataConnector]
 

--- a/test/data/ReferenceDataJsonProjectionSpec.scala
+++ b/test/data/ReferenceDataJsonProjectionSpec.scala
@@ -39,7 +39,7 @@ class ReferenceDataJsonProjectionSpec extends SpecBase {
     implicit val owrites: OWrites[JsObject] = identity[JsObject]
 
     val expectedData = List(Json.obj("int" -> 1), Json.obj("int" -> 2))
-    val testData     = formatAsReferenceDataJson(expectedData)
+    val testData     = formatAsReferenceDataByteString(expectedData)
 
     val (pub, sub) =
       TestSource
@@ -56,7 +56,7 @@ class ReferenceDataJsonProjectionSpec extends SpecBase {
   "stream returns an error when values in the `data` array are not objects" in {
 
     val expectedData = List("one")
-    val testData     = formatAsReferenceDataJson(expectedData)
+    val testData     = formatAsReferenceDataByteString(expectedData)
 
     val (pub, sub) =
       TestSource
@@ -76,15 +76,15 @@ class ReferenceDataJsonProjectionSpec extends SpecBase {
 
 object ReferenceDataJsonProjectionSpec {
 
-  def formatAsReferenceDataJson[A: Writes](data: Seq[A]): ByteString =
-    ByteString(
-      Json
-        .obj(
-          "_links" -> Json.obj("self" -> "foo"),
-          "meta"   -> Json.obj("meta1" -> "meta1Value"),
-          "id"     -> "idValue",
-          "data"   -> Json.toJson(data)
-        )
-        .toString()
-    )
+  def formatAsReferenceDataByteString[A: Writes](data: Seq[A]): ByteString =
+    ByteString(formatAsReferenceDataJson(data).toString())
+
+  def formatAsReferenceDataJson[A: Writes](data: Seq[A]): JsObject =
+    Json
+      .obj(
+        "_links" -> Json.obj("self" -> "foo"),
+        "meta"   -> Json.obj("meta1" -> "meta1Value"),
+        "id"     -> "idValue",
+        "data"   -> Json.toJson(data)
+      )
 }

--- a/test/data/connector/ConnectorSpecBase.scala
+++ b/test/data/connector/ConnectorSpecBase.scala
@@ -1,4 +1,21 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package data.connector
+
 import base.SpecBaseWithAppPerSuite
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
@@ -8,9 +25,8 @@ import play.api.inject.guice.GuiceableModule
 
 trait ConnectorSpecBase extends SpecBaseWithAppPerSuite with BeforeAndAfterAll {
 
-  protected val server: WireMockServer = new WireMockServer(wireMockConfig().dynamicPort())
-
   /**
+    * The path to the config for the external HTTP call
     *
     * @return The name of the config key for the external service
     */
@@ -24,10 +40,12 @@ trait ConnectorSpecBase extends SpecBaseWithAppPerSuite with BeforeAndAfterAll {
     */
   protected def bindings: Seq[GuiceableModule] = Seq.empty
 
+  protected val server: WireMockServer = new WireMockServer(wireMockConfig().dynamicPort())
+
   override def guiceApplicationBuilder: GuiceApplicationBuilder =
     super.guiceApplicationBuilder
       .configure(
-        portConfigKey -> server.port().toString
+        portConfigKey -> server.port()
       )
       .overrides(bindings: _*)
 

--- a/test/data/connector/ConnectorSpecBase.scala
+++ b/test/data/connector/ConnectorSpecBase.scala
@@ -1,0 +1,49 @@
+package data.connector
+import base.SpecBaseWithAppPerSuite
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import org.scalatest.BeforeAndAfterAll
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.inject.guice.GuiceableModule
+
+trait ConnectorSpecBase extends SpecBaseWithAppPerSuite with BeforeAndAfterAll {
+
+  protected val server: WireMockServer = new WireMockServer(wireMockConfig().dynamicPort())
+
+  /**
+    *
+    * @return The name of the config key for the external service
+    */
+  protected def portConfigKey: String
+
+  /**
+    * An overrideable hook that allows for overriding the configuration
+    * of  guice module in the test suite
+    *
+    * @return Seq of modules binding that will be used by [[org.scalatestplus.play.guice.GuiceOneAppPerSuite]]
+    */
+  protected def bindings: Seq[GuiceableModule] = Seq.empty
+
+  override def guiceApplicationBuilder: GuiceApplicationBuilder =
+    super.guiceApplicationBuilder
+      .configure(
+        portConfigKey -> server.port().toString
+      )
+      .overrides(bindings: _*)
+
+  override def beforeAll(): Unit = {
+    server.start()
+    super.beforeAll()
+  }
+
+  override def beforeEachBlocks: Seq[() => Unit] =
+    super.beforeEachBlocks ++ Seq(
+      () => server.resetAll()
+    )
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    server.stop()
+  }
+
+}

--- a/test/data/connector/RefDataConnectorSpec.scala
+++ b/test/data/connector/RefDataConnectorSpec.scala
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data.connector
+
+import java.util
+
+import akka.util.ByteString
+import com.github.tomakehurst.wiremock.client.WireMock._
+import data.ReferenceDataJsonProjectionSpec
+import models.ReferenceDataList
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+import play.api.http.HeaderNames
+import play.api.http.MimeTypes
+import play.api.libs.json.JsObject
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json
+import play.api.libs.json.Writes
+
+import scala.collection.JavaConverters._
+
+class RefDataConnectorSpec extends ConnectorSpecBase {
+
+  implicit val arbitraryReferenceDataList: Arbitrary[ReferenceDataList] =
+    Arbitrary(Gen.oneOf(ReferenceDataList.values.toList))
+
+  val pathToLists = "/customs-reference-data/lists"
+
+  "get" - {
+    "returns the reference data for a valid reference data list" in {
+
+      val listName         = Arbitrary.arbitrary[ReferenceDataList].sample.value
+      val pathToSingleList = s"$pathToLists/${listName.listName}"
+
+      val listsResponse: JsObject =
+        Json.obj(
+          "_self"           -> Json.obj("href" -> pathToLists),
+          listName.listName -> Json.obj("href" -> pathToSingleList)
+        )
+
+      val refDataList =
+        ReferenceDataJsonProjectionSpec.formatAsReferenceDataJson(
+          Seq(
+            simpleJsObject(1),
+            simpleJsObject(2),
+            simpleJsObject(3)
+          )
+        )
+
+      server.stubFor(
+        get(urlEqualTo(pathToLists))
+          .willReturn(
+            ok()
+              .withHeader(HeaderNames.CONTENT_ENCODING, MimeTypes.JSON)
+              .withBody(listsResponse.toString())
+          )
+      )
+
+      server.stubFor(
+        get(urlEqualTo(pathToSingleList))
+          .willReturn(
+            ok()
+              .withHeader(HeaderNames.CONTENT_ENCODING, MimeTypes.JSON)
+              .withBody(refDataList.toString())
+          )
+      )
+
+      val connector = app.injector.instanceOf[RefDataConnector]
+
+      val result: ByteString = connector.get(listName).futureValue.value
+
+      Json.parse(result.toArray) mustEqual refDataList
+    }
+
+    "return a none when the service doesn't have the list" in {
+
+      val listName         = Arbitrary.arbitrary[ReferenceDataList].sample.value
+      val pathToSingleList = s"$pathToLists/${listName.listName}"
+
+      val listsResponse: JsObject =
+        Json.obj(
+          "_self" -> Json.obj("href" -> pathToLists)
+        )
+
+      val refDataList =
+        ReferenceDataJsonProjectionSpec.formatAsReferenceDataJson(
+          Seq(
+            simpleJsObject(1),
+            simpleJsObject(2),
+            simpleJsObject(3)
+          )
+        )
+
+      server.stubFor(
+        get(urlEqualTo(pathToLists))
+          .willReturn(
+            ok()
+              .withHeader(HeaderNames.CONTENT_ENCODING, MimeTypes.JSON)
+              .withBody(listsResponse.toString())
+          )
+      )
+
+      server.stubFor(
+        get(urlEqualTo(pathToSingleList))
+          .willReturn(
+            ok()
+              .withHeader(HeaderNames.CONTENT_ENCODING, MimeTypes.JSON)
+              .withBody(refDataList.toString())
+          )
+      )
+
+      val connector = app.injector.instanceOf[RefDataConnector]
+
+      val result = connector.get(listName).futureValue
+
+      result must not be defined
+    }
+  }
+
+  /**
+    * @return The name of the config key for the external service
+    */
+  override protected def portConfigKey: String = "microservice.services.customsReferenceData.port"
+
+  def simpleJsObject[A: Writes](value: A): JsObject = Json.obj("key" -> value)
+
+}

--- a/test/data/connector/RefDataConnectorSpec.scala
+++ b/test/data/connector/RefDataConnectorSpec.scala
@@ -27,11 +27,8 @@ import org.scalacheck.Gen
 import play.api.http.HeaderNames
 import play.api.http.MimeTypes
 import play.api.libs.json.JsObject
-import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 import play.api.libs.json.Writes
-
-import scala.collection.JavaConverters._
 
 class RefDataConnectorSpec extends ConnectorSpecBase {
 

--- a/test/data/connector/ReferenceDataListsSpec.scala
+++ b/test/data/connector/ReferenceDataListsSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data.connector
+
+import base.SpecBase
+import models.CircumstanceIndicatorList
+import play.api.libs.json.Json
+
+class ReferenceDataListsSpec extends SpecBase {
+
+  "should read all known lists when there are only known lists" in {
+
+    val testObject =
+      Json.obj(
+        "_self"                            -> Json.obj("href" -> "self/path"),
+        CircumstanceIndicatorList.listName -> Json.obj("href" -> "CircumstanceIndicatorList/path")
+      )
+
+    val expected = ReferenceDataLists(
+      Map(
+        CircumstanceIndicatorList -> "CircumstanceIndicatorList/path"
+      )
+    )
+
+    val result = testObject.as[ReferenceDataLists]
+
+    result mustEqual expected
+  }
+
+  "should read all known lists when there are known lists" in {
+
+    val testObject =
+      Json.obj(
+        "_self"                            -> Json.obj("href" -> "self/path"),
+        CircumstanceIndicatorList.listName -> Json.obj("href" -> "CircumstanceIndicatorList/path"),
+        "UnknownListName"                  -> Json.obj("href" -> "UnknownListName/path")
+      )
+
+    val expected = ReferenceDataLists(
+      Map(
+        CircumstanceIndicatorList -> "CircumstanceIndicatorList/path"
+      )
+    )
+
+    val result = testObject.as[ReferenceDataLists]
+
+    result mustEqual expected
+
+  }
+
+}

--- a/test/data/connector/ReferenceDataListsSpec.scala
+++ b/test/data/connector/ReferenceDataListsSpec.scala
@@ -41,7 +41,7 @@ class ReferenceDataListsSpec extends SpecBase {
     result mustEqual expected
   }
 
-  "should read all known lists when there are known lists" in {
+  "should read all known lists when there are unknown lists" in {
 
     val testObject =
       Json.obj(

--- a/test/data/transform/CountryCodesFullListTransfomSpec.scala
+++ b/test/data/transform/CountryCodesFullListTransfomSpec.scala
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data.transform
+
+import java.time.format.DateTimeFormatter
+
+import base.SpecBase
+import models.CountryCodesFullList
+import play.api.libs.json.Json
+import play.api.libs.json._
+
+class CountryCodesFullListTransfomSpec extends SpecBase {
+
+  val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+
+  "transform" - {
+    "transforms data as a JsSuccess JsObject and keeps the English description" in {
+      val data =
+        """ 
+          |{
+          |  "state": "valid",
+          |  "activeFrom": "2020-01-23",
+          |  "countryCode": "AD",
+          |  "tccEntryDate": "19000101",
+          |  "nctsEntryDate": "19000101",
+          |  "geoNomenclatureCode": "043",
+          |  "countryRegimeCode": "TOC",
+          |  "description": {
+          |    "en": "Andorra",
+          |    "tt": "Andorra"
+          |  }
+          |}
+          |""".stripMargin
+
+      val expected =
+        """
+          |{
+          |  "code": "AD",
+          |  "state": "valid",
+          |  "description": "Andorra"
+          |}
+          |""".stripMargin
+
+      val result = Transformation(CountryCodesFullList).transform.reads(Json.parse(data))
+
+      result.get mustEqual Json.parse(expected)
+
+    }
+
+    "returns a JsError parse error if the json doesn't match the expected schema" - {
+
+      "with missing state" in {
+        val data =
+          """ 
+            |{
+            |  "activeFrom": "2020-01-23",
+            |  "countryCode": "AD",
+            |  "tccEntryDate": "19000101",
+            |  "nctsEntryDate": "19000101",
+            |  "geoNomenclatureCode": "043",
+            |  "countryRegimeCode": "TOC",
+            |  "description": {
+            |    "en": "Andorra",
+            |    "tt": "Andorra"
+            |  }
+            |}
+            |""".stripMargin
+
+        val result =
+          Transformation(CountryCodesFullList).transform
+            .reads(Json.parse(data))
+            .asEither
+            .left
+            .value
+
+        result.length mustEqual 1
+        val (errorPath, _) = result.head
+        errorPath mustEqual (__ \ "state")
+
+      }
+
+      "with missing activeFrom" in {
+        val data =
+          """ 
+            |{
+            |  "state": "valid",
+            |  "countryCode": "AD",
+            |  "tccEntryDate": "19000101",
+            |  "nctsEntryDate": "19000101",
+            |  "geoNomenclatureCode": "043",
+            |  "countryRegimeCode": "TOC",
+            |  "description": {
+            |    "en": "Andorra",
+            |    "tt": "Andorra"
+            |  }
+            |}
+            |""".stripMargin
+
+        val result =
+          Transformation(CountryCodesFullList).transform
+            .reads(Json.parse(data))
+            .asEither
+            .left
+            .value
+
+        result.length mustEqual 1
+        val (errorPath, _) = result.head
+        errorPath mustEqual (__ \ "activeFrom")
+
+      }
+
+      "with missing countryCode" in {
+
+        val data =
+          """ 
+            |{
+            |  "state": "valid",
+            |  "activeFrom": "2020-01-23",
+            |  "tccEntryDate": "19000101",
+            |  "nctsEntryDate": "19000101",
+            |  "geoNomenclatureCode": "043",
+            |  "countryRegimeCode": "TOC",
+            |  "description": {
+            |    "en": "Andorra",
+            |    "tt": "Andorra"
+            |  }
+            |}
+            |""".stripMargin
+
+        val result =
+          Transformation(CountryCodesFullList).transform
+            .reads(Json.parse(data))
+            .asEither
+            .left
+            .value
+
+        result.length mustEqual 1
+        val (errorPath, _) = result.head
+        errorPath mustEqual (__ \ "countryCode")
+
+      }
+
+      "with missing #/description/en field" in {
+        val data =
+          """ 
+            |{
+            |  "state": "valid",
+            |  "activeFrom": "2020-01-23",
+            |  "countryCode": "AD",
+            |  "tccEntryDate": "19000101",
+            |  "nctsEntryDate": "19000101",
+            |  "geoNomenclatureCode": "043",
+            |  "countryRegimeCode": "TOC",
+            |  "description": {
+            |    "tt": "Andorra"
+            |  }
+            |}
+            |""".stripMargin
+
+        val result =
+          Transformation(CountryCodesFullList).transform
+            .reads(Json.parse(data))
+            .asEither
+            .left
+            .value
+
+        result.length mustEqual 1
+        val (errorPath, _) = result.head
+        errorPath mustEqual (__ \ "description" \ "en")
+      }
+
+    }
+
+  }
+
+  "filter" ignore {
+
+    "returns a JsSuccess of None if the country is invalid" ignore {}
+
+    "returns a JsSuccess of None if the country is in the future" ignore {}
+
+  }
+
+}

--- a/test/models/ReferenceDataListSpec.scala
+++ b/test/models/ReferenceDataListSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import base.SpecBase
+import play.api.mvc.PathBindable
+
+class ReferenceDataListSpec extends SpecBase {
+
+  "pathBindable" - {
+    "given a valid list name will return the ReferenceDataList for that list name" in {
+      val testList = ReferenceDataList.values.head
+
+      val result: Either[String, ReferenceDataList] = implicitly[PathBindable[ReferenceDataList]].bind("", testList.listName)
+
+      result.right.value mustEqual testList
+
+    }
+
+    "given an invalid list name will return a left with an error message" in {
+
+      val invalidTestList = "invalidTestList"
+
+      val result: Either[String, ReferenceDataList] = implicitly[PathBindable[ReferenceDataList]].bind("", invalidTestList)
+
+      result.left.value.contains("Unknown reference data list name") mustEqual true
+      result.left.value.contains(invalidTestList) mustEqual true
+    }
+  }
+
+}


### PR DESCRIPTION
- Integrate with `customs-reference-data` and stream data from connector
- Implement streaming of the data elements of the reference data response for a list
- Allow for transformation of a list into format expected by frontend
- Encode mechanism to add business rules to filter out elements (not yet implemented)
- Implement transformation for _CountryCodesFullList_