### PR TITLE
CTCTRADERS-1605 | Adding testOnly Arrival routes to test smaller samp…

### DIFF
--- a/app/api/controllers/testOnly/CountryController.scala
+++ b/app/api/controllers/testOnly/CountryController.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api.controllers.testOnly
+
+import api.services.CountryService
+import api.services.TransitCountryService
+import data.DataRetrieval
+import javax.inject.Inject
+import models.CountryCodesFullList
+import models.ReferenceDataList.Constants.CountryCodesFullListFieldNames
+import play.api.libs.json.Json
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.ControllerComponents
+import uk.gov.hmrc.play.bootstrap.controller.BackendController
+
+import scala.concurrent.ExecutionContext
+
+class CountryController @Inject() (
+  cc: ControllerComponents,
+  countryService: CountryService,
+  transitCountryService: TransitCountryService
+)(implicit ec: ExecutionContext)
+    extends BackendController(cc) {
+
+  def countriesFullList(): Action[AnyContent] =
+    Action {
+      Ok(Json.toJson(countryService.countries))
+    }
+
+  def transitCountries(): Action[AnyContent] =
+    Action {
+      Ok(Json.toJson(transitCountryService.transitCountryCodes))
+    }
+
+  def getCountry(code: String): Action[AnyContent] =
+    Action {
+
+      countryService
+        .getCountryByCode(code)
+        .map {
+          country =>
+            Ok(Json.toJson(country))
+        }
+        .getOrElse {
+          NotFound
+        }
+    }
+}

--- a/app/api/controllers/testOnly/CustomsOfficeController.scala
+++ b/app/api/controllers/testOnly/CustomsOfficeController.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api.controllers.testOnly
+
+import javax.inject.Inject
+import play.api.libs.json.Json
+import play.api.mvc.Action
+import play.api.mvc.AnyContent
+import play.api.mvc.ControllerComponents
+import api.services._
+import uk.gov.hmrc.play.bootstrap.controller.BackendController
+
+class CustomsOfficeController @Inject() (
+  cc: ControllerComponents,
+  customsOfficesService: CustomsOfficesService
+) extends BackendController(cc) {
+
+  def customsOffices(): Action[AnyContent] =
+    Action {
+
+      Ok(Json.toJson(customsOfficesService.customsOffices))
+    }
+
+  def customsOfficesOfTheCountry(countryCode: String): Action[AnyContent] =
+    Action {
+
+      Ok(Json.toJson(customsOfficesService.getCustomsOfficesOfTheCountry(countryCode)))
+    }
+
+  def getCustomsOffice(officeId: String): Action[AnyContent] =
+    Action {
+
+      customsOfficesService
+        .getCustomsOffice(officeId)
+        .map {
+          customsOffice =>
+            Ok(Json.toJson(customsOffice))
+        }
+        .getOrElse {
+          NotFound
+        }
+    }
+}

--- a/app/api/services/CountryService.scala
+++ b/app/api/services/CountryService.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api.services
+
+import api.models.Country
+import javax.inject.Inject
+import play.api.Environment
+
+class CountryService @Inject() (override val env: Environment, config: ResourceConfig) extends ResourceService {
+
+  val countries: Seq[Country] =
+    getData[Country](config.countryCodes).sortBy(_.description)
+
+  def getCountryByCode(code: String): Option[Country] =
+    getData[Country](config.countryCodes).find(_.code == code)
+}

--- a/app/api/services/CustomsOfficesService.scala
+++ b/app/api/services/CustomsOfficesService.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api.services
+
+import api.models.CustomsOffice
+import javax.inject.Inject
+import play.api.Environment
+
+class CustomsOfficesService @Inject() (override val env: Environment, config: ResourceConfig) extends ResourceService {
+
+  val customsOffices: Seq[CustomsOffice] =
+    getData[CustomsOffice](config.customsOffice).sortBy(_.name)
+
+  def getCustomsOffice(officeId: String): Option[CustomsOffice] =
+    getData[CustomsOffice](config.customsOffice).find(_.id == officeId)
+
+  def getCustomsOfficesOfTheCountry(countryId: String): Seq[CustomsOffice] =
+    getData[CustomsOffice](config.customsOffice).filter(_.countryId == countryId).sortBy(_.name)
+}

--- a/app/api/services/ResourceConfig.scala
+++ b/app/api/services/ResourceConfig.scala
@@ -50,4 +50,13 @@ class ResourceConfig @Inject() (config: Configuration) {
 
   val circumstanceIndicators: String =
     config.get[String]("resourceFiles.circumstanceIndicators")
+
+  val customsOffice: String =
+    config.get[String]("resourceFiles.customsOffices")
+
+  val countryCodes: String =
+    config.get[String]("resourceFiles.countryCodesFullList")
+
+  val transitCountryCodes: String =
+    config.get[String]("resourceFiles.transitCountryCodesFullList")
 }

--- a/app/api/services/TransitCountryService.scala
+++ b/app/api/services/TransitCountryService.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api.services
+
+import api.models.Country
+import javax.inject.Inject
+import play.api.Environment
+
+class TransitCountryService @Inject() (override val env: Environment, config: ResourceConfig) extends ResourceService {
+
+  val transitCountryCodes: Seq[Country] =
+    getData[Country](config.transitCountryCodes).sortBy(_.description)
+}

--- a/app/repositories/ImportId.scala
+++ b/app/repositories/ImportId.scala
@@ -33,7 +33,8 @@ case class ImportId(value: Int)
 object ImportId {
 
   implicit val writes: Writes[ImportId] = Writes {
-    importId => JsNumber(importId.value)
+    importId =>
+      JsNumber(importId.value)
   }
 
   implicit val reads: Reads[ImportId] = new Reads[ImportId] {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -178,6 +178,9 @@ microservice {
 }
 
 resourceFiles {
+    countryCodesFullList        = "resources/countryCodesFullList.json"
+    customsOffices              = "resources/customsOffices.json"
+    transitCountryCodesFullList = "resources/transitCountries.json"
     additionalInformation       = "resources/additionalInformation.json"
     kindsOfPackage              = "resources/kindsOfPackage.json"
     documentTypes               = "resources/documentTypes.json"

--- a/conf/resources/countryCodesFullList.json
+++ b/conf/resources/countryCodesFullList.json
@@ -1,0 +1,17 @@
+[
+  {
+    "code": "CM",
+    "state": "valid",
+    "description": "Cameroon"
+  },
+  {
+    "code": "CN",
+    "state": "valid",
+    "description": "China"
+  },
+  {
+    "code": "It",
+    "state": "valid",
+    "description": "Italy"
+  }
+]

--- a/conf/resources/customsOffices.json
+++ b/conf/resources/customsOffices.json
@@ -1,0 +1,40 @@
+[
+  {
+  "CUST_OFF_ID": "GB000040",
+  "CUST_OFF_NAM": "Dover (OTS) Freight Clearance",
+  "COUNTRY_ID": "GB",
+  "PHONE_NUMBER": "+44 (0)3000 575 988",
+  "CITY": "HARWICH",
+  "CUSTOMS_OFFICE_ROLES": [
+    "ENT",
+    "EXP",
+    "EXT"
+  ]
+},
+  {
+  "CUST_OFF_ID": "GB000060",
+  "CUST_OFF_NAM": "Dover/Folkestone Eurotunnel Freight",
+  "COUNTRY_ID": "GB",
+  "PHONE_NUMBER": "+44 (0)3000 515831",
+  "CITY": "DOVER",
+  "CUSTOMS_OFFICE_ROLES": [
+  "DEP",
+  "DES",
+  "ENT",
+  "EXP",
+  "TRA"
+  ]
+  },
+  {
+    "CUST_OFF_ID": "GB000244",
+    "CUST_OFF_NAM": "BOSTON",
+    "COUNTRY_ID": "GB",
+    "PHONE_NUMBER": "+44 (0)3000 575 988",
+    "CITY": "HARWICH",
+    "CUSTOMS_OFFICE_ROLES": [
+      "ENT",
+      "EXP",
+      "EXT"
+    ]
+  }
+]

--- a/conf/resources/transitCountries.json
+++ b/conf/resources/transitCountries.json
@@ -1,0 +1,32 @@
+[
+  {
+    "code":"GB",
+    "state":"valid",
+    "description":"United Kingdom"
+  },
+  {
+    "code":"AD",
+    "state":"valid",
+    "description":"Andorra"
+  },
+  {
+    "code": "BE",
+    "state": "valid",
+    "description": "Belgium"
+  },
+  {
+    "code": "FR",
+    "state": "valid",
+    "description": "France"
+  },
+  {
+    "code":"GG",
+    "state":"valid",
+    "description":"Guernsey"
+  },
+  {
+    "code": "IT",
+    "state": "valid",
+    "description": "Italy"
+  }
+]

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -9,5 +9,16 @@
 # !!!WARNING!!! Every route defined in this file MUST be prefixed with "/test-only/". This is because NGINX is blocking every uri containing the string "test-only" in production.
 # Failing to follow this rule may result in test routes deployed in production.
 
+# microservice specific routes
+GET        /transit-movements-trader-reference-data/customs-offices                                   api.controllers.testOnly.CustomsOfficeController.customsOffices
+GET        /transit-movements-trader-reference-data/customs-offices/:code                             api.controllers.testOnly.CustomsOfficeController.customsOfficesOfTheCountry(code)
+GET        /transit-movements-trader-reference-data/customs-office/:id                                api.controllers.testOnly.CustomsOfficeController.getCustomsOffice(id)
+
+GET        /transit-movements-trader-reference-data/countries/:code                                   api.controllers.testOnly.CountryController.getCountry(code)
+GET        /transit-movements-trader-reference-data/countries-full-list                               api.controllers.testOnly.CountryController.countriesFullList
+GET        /transit-movements-trader-reference-data/transit-countries                                 api.controllers.testOnly.CountryController.transitCountries
+
 # Add all the application routes to the prod.routes file
-->         /                          prod.Routes
+->         /                          health.Routes
+
+GET        /admin/metrics             com.kenshoo.play.metrics.MetricsController.metrics


### PR DESCRIPTION
…le of reference data.  TODO Departures routes

Interim solution to allow Arrivals journey tests to be reinstated to the pipeline.  Longer term solution to use endpoint to seed data to reference mongo collection.