### PR TITLE
CTCP-791 Add /test-only/ prefix to routes

### DIFF
--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -10,52 +10,52 @@
 # Failing to follow this rule may result in test routes deployed in production.
 
 # microservice specific routes
-GET        /transit-movements-trader-reference-data/customs-offices                                   controllers.testOnly.CustomsOfficeController.customsOffices
-GET        /transit-movements-trader-reference-data/customs-offices/:code                             controllers.testOnly.CustomsOfficeController.customsOfficesOfTheCountry(code, role: List[String] ?= Nil)
-GET        /transit-movements-trader-reference-data/customs-office/:id                                controllers.testOnly.CustomsOfficeController.getCustomsOffice(id)
-GET        /transit-movements-trader-reference-data/customs-office-transit/:code                      controllers.testOnly.CustomsOfficeController.customsOfficeTransit(code)
-GET        /transit-movements-trader-reference-data/customs-office-departure/:code                    controllers.testOnly.CustomsOfficeController.customsOfficeDeparture(code)
-GET        /transit-movements-trader-reference-data/customs-office-destination/:code                  controllers.testOnly.CustomsOfficeController.customsOfficeDestination(code)
-GET        /transit-movements-trader-reference-data/customs-office-exit/:code                         controllers.testOnly.CustomsOfficeController.customsOfficeExit(code)
-GET        /transit-movements-trader-reference-data/customs-office-transit-exit/:code                 controllers.testOnly.CustomsOfficeController.customsOfficeTransitExit(code)
+GET        /test-only/transit-movements-trader-reference-data/customs-offices                                   controllers.testOnly.CustomsOfficeController.customsOffices
+GET        /test-only/transit-movements-trader-reference-data/customs-offices/:code                             controllers.testOnly.CustomsOfficeController.customsOfficesOfTheCountry(code, role: List[String] ?= Nil)
+GET        /test-only/transit-movements-trader-reference-data/customs-office/:id                                controllers.testOnly.CustomsOfficeController.getCustomsOffice(id)
+GET        /test-only/transit-movements-trader-reference-data/customs-office-transit/:code                      controllers.testOnly.CustomsOfficeController.customsOfficeTransit(code)
+GET        /test-only/transit-movements-trader-reference-data/customs-office-departure/:code                    controllers.testOnly.CustomsOfficeController.customsOfficeDeparture(code)
+GET        /test-only/transit-movements-trader-reference-data/customs-office-destination/:code                  controllers.testOnly.CustomsOfficeController.customsOfficeDestination(code)
+GET        /test-only/transit-movements-trader-reference-data/customs-office-exit/:code                         controllers.testOnly.CustomsOfficeController.customsOfficeExit(code)
+GET        /test-only/transit-movements-trader-reference-data/customs-office-transit-exit/:code                 controllers.testOnly.CustomsOfficeController.customsOfficeTransitExit(code)
 
-GET        /transit-movements-trader-reference-data/countries                                         controllers.testOnly.CountryController.get(countryQueryFilter: CountryQueryFilter)
-GET        /transit-movements-trader-reference-data/countries/:code                                   controllers.testOnly.CountryController.getCountry(code)
-GET        /transit-movements-trader-reference-data/country-customs-office-security-agreement-area    controllers.testOnly.CountryController.getCountryCustomsOfficeSecurityAgreementArea
-GET        /transit-movements-trader-reference-data/country-address-postcode-based                    controllers.testOnly.CountryController.getCountryAddressPostcodeBased
-GET        /transit-movements-trader-reference-data/country-codes-ctc                                 controllers.testOnly.CountryController.getCountryCodesCTC
+GET        /test-only/transit-movements-trader-reference-data/countries                                         controllers.testOnly.CountryController.get(countryQueryFilter: CountryQueryFilter)
+GET        /test-only/transit-movements-trader-reference-data/countries/:code                                   controllers.testOnly.CountryController.getCountry(code)
+GET        /test-only/transit-movements-trader-reference-data/country-customs-office-security-agreement-area    controllers.testOnly.CountryController.getCountryCustomsOfficeSecurityAgreementArea
+GET        /test-only/transit-movements-trader-reference-data/country-address-postcode-based                    controllers.testOnly.CountryController.getCountryAddressPostcodeBased
+GET        /test-only/transit-movements-trader-reference-data/country-codes-ctc                                 controllers.testOnly.CountryController.getCountryCodesCTC
 
-GET        /transit-movements-trader-reference-data/office-transit                                    controllers.testOnly.OfficeOfTransitController.officesOfTransit
-GET        /transit-movements-trader-reference-data/office-transit/:id                                controllers.testOnly.OfficeOfTransitController.getOfficeOfTransit(id)
+GET        /test-only/transit-movements-trader-reference-data/office-transit                                    controllers.testOnly.OfficeOfTransitController.officesOfTransit
+GET        /test-only/transit-movements-trader-reference-data/office-transit/:id                                controllers.testOnly.OfficeOfTransitController.getOfficeOfTransit(id)
 
-GET        /transit-movements-trader-reference-data/transport-modes                                   controllers.testOnly.TransportModeController.transportModes
-GET        /transit-movements-trader-reference-data/transport-mode/:code                              controllers.testOnly.TransportModeController.getTransportMode(code)
+GET        /test-only/transit-movements-trader-reference-data/transport-modes                                   controllers.testOnly.TransportModeController.transportModes
+GET        /test-only/transit-movements-trader-reference-data/transport-mode/:code                              controllers.testOnly.TransportModeController.getTransportMode(code)
 
-GET        /transit-movements-trader-reference-data/previous-document-types                           controllers.testOnly.PreviousDocumentTypeController.previousDocumentTypes
-GET        /transit-movements-trader-reference-data/previous-document-type/:code                      controllers.testOnly.PreviousDocumentTypeController.getPreviousDocumentType(code)
+GET        /test-only/transit-movements-trader-reference-data/previous-document-types                           controllers.testOnly.PreviousDocumentTypeController.previousDocumentTypes
+GET        /test-only/transit-movements-trader-reference-data/previous-document-type/:code                      controllers.testOnly.PreviousDocumentTypeController.getPreviousDocumentType(code)
 
-GET        /transit-movements-trader-reference-data/circumstance-indicators                           controllers.testOnly.CircumstanceIndicatorController.circumstanceIndicators
-GET        /transit-movements-trader-reference-data/circumstance-indicator/:code                      controllers.testOnly.CircumstanceIndicatorController.getCircumstanceIndicator(code)
+GET        /test-only/transit-movements-trader-reference-data/circumstance-indicators                           controllers.testOnly.CircumstanceIndicatorController.circumstanceIndicators
+GET        /test-only/transit-movements-trader-reference-data/circumstance-indicator/:code                      controllers.testOnly.CircumstanceIndicatorController.getCircumstanceIndicator(code)
 
-GET        /transit-movements-trader-reference-data/control-results                                   controllers.testOnly.ControlResultTestController.getAll()
-GET        /transit-movements-trader-reference-data/control-results/:code                             controllers.testOnly.ControlResultTestController.getControlResult(code)
+GET        /test-only/transit-movements-trader-reference-data/control-results                                   controllers.testOnly.ControlResultTestController.getAll()
+GET        /test-only/transit-movements-trader-reference-data/control-results/:code                             controllers.testOnly.ControlResultTestController.getControlResult(code)
 
-GET        /transit-movements-trader-reference-data/method-of-payment                                 controllers.testOnly.MethodOfPaymentController.methodOfPayment
+GET        /test-only/transit-movements-trader-reference-data/method-of-payment                                 controllers.testOnly.MethodOfPaymentController.methodOfPayment
 
-GET        /transit-movements-trader-reference-data/dangerous-goods-codes                             controllers.testOnly.DangerousGoodsCodeController.dangerousGoodsCodes
-GET        /transit-movements-trader-reference-data/dangerous-goods-code/:code                        controllers.testOnly.DangerousGoodsCodeController.getDangerousGoodsCode(code)
+GET        /test-only/transit-movements-trader-reference-data/dangerous-goods-codes                             controllers.testOnly.DangerousGoodsCodeController.dangerousGoodsCodes
+GET        /test-only/transit-movements-trader-reference-data/dangerous-goods-code/:code                        controllers.testOnly.DangerousGoodsCodeController.getDangerousGoodsCode(code)
 
-GET        /transit-movements-trader-reference-data/additional-information                            controllers.testOnly.AdditionalInformationController.additionalInformation
+GET        /test-only/transit-movements-trader-reference-data/additional-information                            controllers.testOnly.AdditionalInformationController.additionalInformation
 
-GET        /transit-movements-trader-reference-data/kinds-of-package                                  controllers.testOnly.KindOfPackageController.kindsOfPackage
+GET        /test-only/transit-movements-trader-reference-data/kinds-of-package                                  controllers.testOnly.KindOfPackageController.kindsOfPackage
 
-GET        /transit-movements-trader-reference-data/document-types                                    controllers.testOnly.DocumentTypeController.documentTypes
+GET        /test-only/transit-movements-trader-reference-data/document-types                                    controllers.testOnly.DocumentTypeController.documentTypes
 
-GET        /transit-movements-trader-reference-data/un-locodes                                        controllers.testOnly.UnLocodeController.get
+GET        /test-only/transit-movements-trader-reference-data/un-locodes                                        controllers.testOnly.UnLocodeController.get
 
-GET        /transit-movements-trader-reference-data/qualifier-of-identification-incident              controllers.testOnly.QualifierOfIdentificationIncidentController.get
+GET        /test-only/transit-movements-trader-reference-data/qualifier-of-identification-incident              controllers.testOnly.QualifierOfIdentificationIncidentController.get
 
-GET        /transit-movements-trader-reference-data/country-without-zip                               controllers.testOnly.CountryWithoutZipController.get
+GET        /test-only/transit-movements-trader-reference-data/country-without-zip                               controllers.testOnly.CountryWithoutZipController.get
 
 # Add all the application routes to the prod.routes file
 ->         /                          health.Routes


### PR DESCRIPTION
Can therefore point P5 frontends to /test-only/ routes with config override whist P4 remains on production router
This is being done by exposing the play.http.router.